### PR TITLE
Fix World Clear On Load Issue

### DIFF
--- a/PassengerJobs.csproj
+++ b/PassengerJobs.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PassengerJobsMod</RootNamespace>
     <AssemblyName>PassengerJobs</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/Patches_JobSaveManager.cs
+++ b/Patches_JobSaveManager.cs
@@ -179,7 +179,7 @@ namespace PassengerJobsMod
                     if( jobData is PassengerJobDefinitionData pjData )
                     {
                         jobDefinition = CreateSavedPassengerJob(jobChainGO, pjData);
-                        jobDefinition.ForceJobId(passChainData.firstJobId);
+                        jobDefinition?.ForceJobId(passChainData.firstJobId);
                         chainData = new StationsChainData(jobData.originStationId, jobData.destinationStationId);
                     }
                     else
@@ -218,7 +218,7 @@ namespace PassengerJobsMod
                         if( first )
                         {
                             chainData = new StationsChainData(jobData.originStationId, jobData.destinationStationId);
-                            jobDefinition.ForceJobId(passChainData.firstJobId);
+                            jobDefinition?.ForceJobId(passChainData.firstJobId);
                             first = false;
                         }
                     }


### PR DESCRIPTION
Because track GF-C-2-LP got removed from the platform track list in v2.1.0, `CreateSavedPassengerJob` could return null when loading a save file that defines a train/job on that track. `CreateSavedJobChain` was not written in a way to account for the possibility of a null return value from `CreateSavedPassegnerJob`, which caused a NullReferenceException in this case. The base game's job loader handles NREs by clearing all cars/jobs in the world, which is a less than desirable thing to have happen. Luckily we can avoid this issue.

This PR fixes the NRE that used to occur when a saved passenger job couldn't be loaded. I also had to change the target framework in order to get the project to build because .NET Framework 4.5 doesn't contain `IEnumerable.ToHashSet`.