### PR TITLE
Remove Origin Station From Destination Pool

### DIFF
--- a/PassengerJobGenerator.cs
+++ b/PassengerJobGenerator.cs
@@ -367,6 +367,9 @@ namespace PassengerJobsMod
             Track destPlatform = null;
             StationController destStation = null;
 
+            // this prevents generating jobs like "ChainJob[Passenger]: FF - FF (FF-PE-47)"
+            destPool.Remove(Controller);
+
             while( (destPlatform == null) && (destPool.Count > 0) )
             {
                 // search the possible destinations 1 by 1 until we find an opening (or we don't)


### PR DESCRIPTION
As I was play testing tonight, I noticed this job get spawned: `ChainJob[Passenger]: FF - FF (FF-PE-47)`

It appears PassengerJobGenerator was including its host StationController in the destination pool. This change removes the host controller from the pool before attempting to choose a destination.