### PR TITLE
compatibility with build 89

### DIFF
--- a/Extensions.cs
+++ b/Extensions.cs
@@ -55,7 +55,7 @@ namespace PassengerJobsMod
             var cars = new List<Car>();
             foreach( string guid in carsPerTrack.carGuids )
             {
-                if( !Car.carGuidToCar.TryGetValue(guid, out Car car) )
+                if( !SingletonBehaviour<IdGenerator>.Instance.carGuidToCar.TryGetValue(guid, out Car car) )
                 {
                     throw new ArgumentException($"No Car corresponding to GUID: {guid}");
                 }

--- a/Patches.cs
+++ b/Patches.cs
@@ -62,7 +62,8 @@ namespace PassengerJobsMod
 
                 if( !string.IsNullOrEmpty(itemData.carGuid) )
                 {
-                    var car = TrainCar.GetTrainCarByCarGuid(itemData.carGuid);
+                    var idGenerator = SingletonBehaviour<IdGenerator>.Instance;
+                    var car = idGenerator.logicCarToTrainCar[idGenerator.carGuidToCar[itemData.carGuid]];
                     if( car )
                     {
                         if( car.GetComponent<TrainPhysicsLod>() is TrainPhysicsLod carPhysics )
@@ -126,7 +127,7 @@ namespace PassengerJobsMod
         const string EXPRESS_TYPE = "PE";
         const string COMMUTE_TYPE = "PC";
 
-        static bool Prefix( JobType jobType, StationsChainData jobStationsInfo, ref string __result, 
+        static bool Prefix( IdGenerator __instance, JobType jobType, StationsChainData jobStationsInfo, ref string __result, 
             System.Random ___idRng, HashSet<string> ___existingJobIds )
         {
             if( (jobType != PassJobType.Express) &&
@@ -151,7 +152,7 @@ namespace PassengerJobsMod
 
                 if( !___existingJobIds.Contains(idStr) )
                 {
-                    IdGenerator.RegisterJobId(idStr);
+                    __instance.RegisterJobId(idStr);
                     __result = idStr;
                     return false;
                 }

--- a/Patches_JobSaveManager.cs
+++ b/Patches_JobSaveManager.cs
@@ -40,7 +40,7 @@ namespace PassengerJobsMod
             var result = new List<Car>();
             for( int i = 0; i < carGuids.Length; i++ )
             {
-                if( !Car.carGuidToCar.TryGetValue(carGuids[i], out Car car) )
+                if( !SingletonBehaviour<IdGenerator>.Instance.carGuidToCar.TryGetValue(carGuids[i], out Car car) )
                 {
                     Debug.LogError("Couldn't find corresponding Car for carGuid:" + carGuids[i] + "!");
                     return null;
@@ -62,13 +62,13 @@ namespace PassengerJobsMod
 
             foreach( string guid in carGuids )
             {
-                if( !Car.carGuidToCar.TryGetValue(guid, out Car car) || car == null )
+                if( !SingletonBehaviour<IdGenerator>.Instance.carGuidToCar.TryGetValue(guid, out Car car) || car == null )
                 {
                     PrintError($"Couldn't find corresponding Car for carGuid:{guid}!");
                     return null;
                 }
 
-                if( !TrainCar.logicCarToTrainCar.TryGetValue(car, out TrainCar trainCar) || !(trainCar != null) )
+                if( !SingletonBehaviour<IdGenerator>.Instance.logicCarToTrainCar.TryGetValue(car, out TrainCar trainCar) || !(trainCar != null) )
                 {
                     PrintError($"Couldn't find corresponding TrainCar for Car: {car.ID} with carGuid:{guid}!");
                     return null;

--- a/PlatformController.cs
+++ b/PlatformController.cs
@@ -296,7 +296,7 @@ namespace PassengerJobsMod
                     {
                         foreach( Car car in task.cars )
                         {
-                            if( TrainCar.logicCarToTrainCar.TryGetValue(car, out TrainCar trainCar) )
+                            if( SingletonBehaviour<IdGenerator>.Instance.logicCarToTrainCar.TryGetValue(car, out TrainCar trainCar) )
                             {
                                 if( trainCar.GetForwardSpeed() > 0.3f )
                                 {


### PR DESCRIPTION
This doesn't solve all of the compatibility issues with the latest build (89), but it handles all the ones that break the build.

On game load, I'm getting this error, which I haven't been able to track down yet. It appears to prevent the save file from loading properly and to wipe job/car save data:

```
System.TypeInitializationException: The type initializer for 'PassengerJobsMod.JSM_LoadJobChain_Patch' threw an exception. ---> System.ArgumentException: method arguments are incompatible
  at System.Delegate.CreateDelegate (System.Type type, System.Object firstArgument, System.Reflection.MethodInfo method, System.Boolean throwOnBindFailure, System.Boolean allowClosed) [0x002e3] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Delegate.CreateDelegate (System.Type type, System.Reflection.MethodInfo method, System.Boolean throwOnBindFailure) [0x00000] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Delegate.CreateDelegate (System.Type type, System.Reflection.MethodInfo method) [0x00000] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Reflection.RuntimeMethodInfo.CreateDelegate (System.Type delegateType) [0x00000] in <567df3e0919241ba98db88bec4c6696f>:0 
  at PassengerJobsMod.JSM_LoadJobChain_Patch..cctor () [0x00010] in <683859f0e472489c8a55ee0d2c10a29d>:0 
   --- End of inner exception stack trace ---
  at (wrapper dynamic-method) JobSaveManager.JobSaveManager.LoadJobChain_Patch1(JobSaveManager,JobChainSaveData)
  at JobSaveManager.LoadJobSaveGameData (JobsSaveGameData saveData) [0x00089] in <7e087b30bb0c464eaa6d81dab84098c6>:0 
  at SaveLoadController+<Start>d__3.MoveNext () [0x007aa] in <7e087b30bb0c464eaa6d81dab84098c6>:0
```

I'll keep investigating when I can find time to, but if you have better/faster luck than me, feel free to use this branch to springboard your investigation.