### PR TITLE
Carriage interior lighting behaviour

### DIFF
--- a/PassengerJobs/PJModSettings.cs
+++ b/PassengerJobs/PJModSettings.cs
@@ -11,6 +11,9 @@ namespace PassengerJobs
         [Draw("Disable passenger coach interior lights")]
         public bool DisableCoachLights = false;
 
+        [Draw("Passenger coach interior lights require loco power", VisibleOn = "DisableCoachLights|false", Tooltip = "Main fuse on or dynamo running")]
+        public bool CoachLightsRequirePower = true;
+
 #if DEBUG
         [Draw("Reload rural stations config")]
         public bool ReloadStations = false;

--- a/PassengerJobs/PassengerJobs.csproj
+++ b/PassengerJobs/PassengerJobs.csproj
@@ -20,6 +20,7 @@
 		<Reference Include="DV.BrakeSystem" />
 		<Reference Include="DV.Common" />
 		<Reference Include="DV.PointSet" />
+		<Reference Include="DV.Simulation" />
 		<Reference Include="DV.Utils" />
 		<Reference Include="DV.WeatherSystem" />
 		<Reference Include="DVLangHelper.Data" />
@@ -62,4 +63,7 @@
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </None>
 	</ItemGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(DvInstallDir)\Mods\PassengerJobs\" />
+  </Target>
 </Project>


### PR DESCRIPTION
Added a new setting 'CoachLightsRequirePower'.

When enabled, at least one loco in the train must provide power for passenger carriage interior lights and tail lights to function.

A loco is considered to be providing power if:
 - Loco is a diesel and main/"electrics" breaker is turned on
 - Loco is a steam loco and the dynamo is on and has sufficient steam pressure to operate

Locos are now detected using the `TrainSetChanged` event and checking if the Trainset contains any loco indicies.