### PR TITLE
Fuse Fix, Light Improvements

### DIFF
--- a/PassengerJobs/Extensions.cs
+++ b/PassengerJobs/Extensions.cs
@@ -89,5 +89,19 @@ namespace PassengerJobs
         {
             return LogicController.Instance.LogicToRailTrack[track];
         }
+
+        public static IEnumerable<TrainCar> GetLocomotives(this Trainset trainset)
+        {
+            var indices = trainset.locoIndices;
+
+            foreach (var index in indices)
+            {
+                var car = trainset.cars[index];
+
+                if (car == null) continue;
+
+                yield return car;
+            }
+        }
     }
 }

--- a/PassengerJobs/LampHelper.cs
+++ b/PassengerJobs/LampHelper.cs
@@ -93,7 +93,8 @@ namespace PassengerJobs
 
                 if (!s_litColor.HasValue)
                 {
-                    s_litColor = DE2.prefab.GetComponentInChildren<CabLightsController>().lightsLit.GetColor("_EmissionColor") * 0.6f;
+                    s_litColor = Color.LerpUnclamped(Color.grey,
+                        DE2.prefab.GetComponentInChildren<CabLightsController>().lightsLit.GetColor("_EmissionColor"), 0.7f) * 0.7f;
                 }
 
                 return s_litColor.Value;

--- a/PassengerJobs/NightLightController.cs
+++ b/PassengerJobs/NightLightController.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using DV.Customization;
+using System.Linq;
 using UnityEngine;
 
 namespace PassengerJobs
@@ -243,14 +244,13 @@ namespace PassengerJobs
 
         private bool AnyLocoPowered()
         {
-            foreach (var index in _trainCar.trainset.locoIndices)
+            foreach (var loco in _trainCar.trainset.GetLocomotives())
             {
-                var loco = _trainCar.trainset?.cars[index];
-                if (loco == null) continue;
-
-                //steam locos also have a cabLightsController, the power fuse is the dynamo
-                var cabLights = loco.SimController.cabLightsController;
-                if (cabLights && (cabLights.powerFuse?.State == true))
+                // To keep CCL compatibility, use TrainCarCustomization to
+                // get the main fuse state.
+                if (loco.TryGetComponent(out TrainCarCustomization tcc) &&
+                    tcc.electronicsFuse != null &&
+                    tcc.electronicsFuse.State)
                 {
                     return true;
                 }

--- a/PassengerJobs/Patches/CarSpawnerPatch.cs
+++ b/PassengerJobs/Patches/CarSpawnerPatch.cs
@@ -68,6 +68,7 @@ namespace PassengerJobs.Patches
         {
             parent.localPosition = new Vector3(0, 3.75f, 0);
 
+            AddLightAtOffset(parent, new Vector3(0, 0, 10.6f));
             AddLightAtOffset(parent, new Vector3(0, 0, 8));
             AddLightAtOffset(parent, new Vector3(0, 0, 6));
             AddLightAtOffset(parent, new Vector3(0, 0, 4));
@@ -77,6 +78,7 @@ namespace PassengerJobs.Patches
             AddLightAtOffset(parent, new Vector3(0, 0, -4));
             AddLightAtOffset(parent, new Vector3(0, 0, -6));
             AddLightAtOffset(parent, new Vector3(0, 0, -8));
+            AddLightAtOffset(parent, new Vector3(0, 0, -10.6f));
             //AddDirectionalLight(lightHolder.transform, new Vector3(-1.5f, -1.5f, 0), DirLightRotationL);
             //AddDirectionalLight(lightHolder.transform, new Vector3(1.5f, -1.5f, 0), DirLightRotationR);
         }
@@ -99,10 +101,10 @@ namespace PassengerJobs.Patches
 
             var light = holder.AddComponent<Light>();
             light.type = LightType.Point;
-            light.spotAngle = 135.0f;
+            light.spotAngle = 125.0f;
             light.color = LampHelper.LitColour;
-            light.intensity = 2.5f;
-            light.range = 3.0f;
+            light.intensity = 2.1f;
+            light.range = 2.8f;
 
             //light.shadows = LightShadows.Soft;
             //light.shadowResolution = LightShadowResolution.Low;


### PR DESCRIPTION
Added 2 missing lights to the interior.
Changed interior light colours to reduce reflection intensity.
Changed locomotive power check to use `TrainCarCustomisation` instead of the cab lights.
* This is future proofing for CCL. Not all locomotives may have cab lights, however all power is routed through `TrainCarCustomisation`, which also controls the ability to power gadgets. So I believe it is a better solution to get the main fuse's state.